### PR TITLE
Update nlp sig

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 | Thursday 2023-03-02 13:30 | 5    | [GPU #1](granted/gpu.md)                                      |          |
 | Thursday 2023-03-02 14:30 | 6    | [Analytics #2](granted/analytics.md)                          | Artur    |
 | Thursday 2023-03-09 9:30  | 7    | [Soft Skills](granted/soft-skills.md)                         | Jaro     |
-| Thursday 2023-03-09 13:30 | 8    | [Natural Language Processing](granted/nlp.md)                 | Erik     |
+| Thursday 2023-03-09 13:30 | 8    | [Natural Language Processing](granted/nlp.md)                 | Laura    |
 | Thursday 2023-03-09 14:30 | 9    | [Science Communication](granted/scicomm.md)                   | Pablo R. |
 | Thursday 2023-03-16 9:30  | 10   | [Quantum Computing](granted/qc.md)                            | Pranav   |
 | Thursday 2023-03-16 13:30 | 11   | [Machine Learning](granted/machine-learning.md)               |          |

--- a/granted/nlp.md
+++ b/granted/nlp.md
@@ -19,14 +19,22 @@ https://github.com/nlesc-sigs/nlp-sig
 ## What is the Office group that the SIG uses?
 eHumanities
 
-## SIG outcomes in the period April 2020 - October 2020 (for existing SIGs)
-- **General meetings**: 
-20200629 and 20200928
+## SIG outcomes of the past year (2022)
+| Date | Session leader | People | Topic |
+|------|----------------|--------|-------|
+| 2022-12-12 | Erik | 9 | Project status and Bert Brainstorm |
+| 2022-11-14 | Jisk | 6 | NLP @ NLeSC and Bert Brainstorm |
+| 2022-10-17 | Ole  | 9 | Guest talk by Marijn Koolen: What can Online Book Reviews tell us about Readers and Platforms | 
+| 2022-09-19 | Erik | 7 | NLP @ NLeSC | 
+| 2022-05-30 | Erik |10 | Guest talk by Suzan Verberne: Text mining for health knowledge discovery from social media | 
+| 2022-05-02 | Dafne| 5 | NLP @ NLeSC and [Video discussion](https://www.youtube.com/watch?v=N5c2X8vhfBE) |
+| 2022-04-04 | Jisk | 9 | NLP @ NLeSC and [Video discussion](https://underline.io/events/122/sessions/4318/lecture/22613-industry-invited-talk-project-debater---from-grand-challenge-to-business-applications,-behind-the-scenes-and-lessons-learned---aya-soffer) |
+| 2022-03-07 | Erik | 7 | NLP @ NLeSC and [Video discussion](https://www.youtube.com/watch?v=-G09F856lU4) |
+| 2022-02-07 | Erik | 7 | NLP @ NLeSC and [Paper discussion](https://aclanthology.org/2021.emnlp-main.818/) |
+| 2022-01-10 | Erik | 5 | NLP @ NLeSC |
 
-- **Course meetings (Deep Learning for NLP)**: 
-20200518, 20200615 and 20201008
 
-## Plans for the period until the end of October 2020
+## Plans for the coming year
 <!--  help text goes here  -->
 - **Finish course Deep Learning for NLP**: we have one [https://www.youtube.com/playlist?list=PLoROMvodv4rOhcuXMZkNm7j3fVwBBY42z](video lecture) left and might want to add one or two hands-on sessions
 - **Continue general meetings**: in which we discuss the progress of the running NLeSC NLP projects

--- a/granted/nlp.md
+++ b/granted/nlp.md
@@ -3,15 +3,18 @@
 ## What is/will be the name of the SIG?
 Natural Language Processing SIG
 
-## Which two persons will act as SIG Leads?
+## Which person will act as SIG Leads?
+- Laura Ootes (l.ootes@esciencecenter.nl)
+
+The co-leads are:
 - Erik Tjong Kim Sang
-- Jisk Attema
+- Carsten Schnober
 
 ## What is SIG’s mission?
 The mission of the Natural Language Processing SIG is to improve the awareness of recent relevant natural language processing techniques among eScience engineers
 
 ## What is the GitHub repository of the SIG use?
-https://github.com/NLeSC/natural-language-processing-sig
+https://github.com/nlesc-sigs/nlp-sig
 
 ## What is the Office group that the SIG uses?
 eHumanities

--- a/granted/nlp.md
+++ b/granted/nlp.md
@@ -7,8 +7,8 @@ Natural Language Processing SIG
 - Laura Ootes (l.ootes@esciencecenter.nl)
 
 The co-leads are:
-- Erik Tjong Kim Sang
-- Carsten Schnober
+- Erik Tjong Kim Sang (e.tjongkimsang(a)esciencenter.nl, was SIG Lead in 2022)
+- Carsten Schnober (c.schnober(at)esciencecenter.nl, will be SIG Lead in 2024)
 
 ## What is SIG’s mission?
 The mission of the Natural Language Processing SIG is to improve the awareness of recent relevant natural language processing techniques among eScience engineers
@@ -34,7 +34,7 @@ eHumanities
 | 2022-01-10 | Erik | 5 | NLP @ NLeSC |
 
 
-## Plans for the coming year
+## Plans for the coming year (2023)
 <!--  help text goes here  -->
 - **Finish course Deep Learning for NLP**: we have one [https://www.youtube.com/playlist?list=PLoROMvodv4rOhcuXMZkNm7j3fVwBBY42z](video lecture) left and might want to add one or two hands-on sessions
 - **Continue general meetings**: in which we discuss the progress of the running NLeSC NLP projects

--- a/granted/nlp.md
+++ b/granted/nlp.md
@@ -50,7 +50,7 @@ Planned sessions:
 
 
 ## What are the expected outputs of the proposed SIG?
-- Improved awareness of natural language processing issues in current eScience projects by increased communication between knowledgeable and interested engineers
-- Better chance of solving bottlenecks in these projects thanks to feedback of our team
-- Enhanced understanding of recent natural language processing techniques among eScience engineers by presentations/courses of recent developments in the field
+- Improve the awareness of natural language processing issues in current eScience projects by increasing the communication between knowledgeable and interested engineers
+- Share knowledge about and experiences with NLP. This will create a better chance of solving bottlenecks in these projects thanks to feedback of our team
+- Enhance the understanding of recent natural language processing techniques among eScience engineers by presentations/courses of recent developments in the field
 

--- a/granted/nlp.md
+++ b/granted/nlp.md
@@ -36,8 +36,18 @@ eHumanities
 
 ## Plans for the coming year (2023)
 <!--  help text goes here  -->
-- **Finish course Deep Learning for NLP**: we have one [https://www.youtube.com/playlist?list=PLoROMvodv4rOhcuXMZkNm7j3fVwBBY42z](video lecture) left and might want to add one or two hands-on sessions
-- **Continue general meetings**: in which we discuss the progress of the running NLeSC NLP projects
+**Continue general meetings**: in which we discuss the progress of the running NLeSC NLP projects
+
+Planned sessions:
+| Date | Time |Topic | More info |
+|------|------|------|------------|
+| Thursday 9 March 2023 | 13:30-14:30 | Erik Tjong Kim Sang: Bert hands-on session ([notebook](https://github.com/eriktks/bert_tutorial)) | [Teams link](https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fmeetup-join%2F19%3Ameeting_ZDJkOWIyMGUtZjgzNC00MmEzLWFiOWUtYTMzY2M1MDZhYmNk%40thread.v2%2F0%3Fcontext%3D%257b%2522Tid%2522%253a%2522aa3aeacc-6307-42b2-ac05-787dd5c32574%2522%252c%2522Oid%2522%253a%2522bcbbafe4-e50f-4f75-9e56-e8a65f2b791e%2522%257d%26anon%3Dtrue&type=meetup-join&deeplinkId=81ecf3d3-6e57-4714-bbdb-5ffe06ff223c&directDl=true&msLaunch=true&enableMobilePage=true) |
+| Thursday 6 April 2023 | 13:30-14:30 | [Roelant Ossewaarde](https://www.internationalhu.com/research/researchers/roelant-ossewaarde): Speech Recognition |  |
+| Thursday 4 May 2023 | 13:30-14:30 |  | (EACL Dubrovnik) |
+| Thursday 1 June 2023 | 13:30-14:30 | Malte L&uuml;ken: The Structural Topic Model: Introduction, application, and challenges |  |
+| Thursday 29 June 2023 | 13:30-14:30 | Eva Viviani: [Paper discussion](https://arxiv.org/pdf/2302.07232.pdf) | |
+
+
 
 ## What are the expected outputs of the proposed SIG?
 - Improved awareness of natural language processing issues in current eScience projects by increased communication between knowledgeable and interested engineers


### PR DESCRIPTION
I updated the NLP SIG mandate according to the new SIG proposal template as Willem requested. The info is similar to the original NLP SIG proposal and the planning and past meetings are copied from the main NLP SIG page.